### PR TITLE
Add keyboard press method

### DIFF
--- a/src/Toppoki.js
+++ b/src/Toppoki.js
@@ -103,3 +103,33 @@ exports._unsafePageEvalAll = function(selector, fnStr, page) {
     return page.$$eval(selector, eval(fnStr));
   };
 };
+
+exports._keyboardDown = function(string, options, page) {
+  return function() {
+    return page.keyboard.down(string, options);
+  };
+};
+
+exports._keyboardPress = function(key, options, page) {
+  return function() {
+    return page.keyboard.press(key, options);
+  };
+};
+
+exports._keyboardSendCharacter = function(char, page) {
+  return function() {
+    return page.keyboard.sendCharacter(char);
+  };
+};
+
+exports._keyboardType = function(text, options, page) {
+  return function() {
+    return page.keyboard.type(text, options);
+  };
+};
+
+exports._keyboardUp = function(string, options, page) {
+  return function() {
+    return page.keyboard.up(string, options);
+  };
+};

--- a/src/Toppoki.js
+++ b/src/Toppoki.js
@@ -91,3 +91,15 @@ exports._unsafeEvaluateStringFunction = function(string, page) {
     return page.evaluate(string);
   };
 };
+
+exports._unsafePageEval = function(selector, fnStr, page) {
+  return function() {
+    return page.$eval(selector, eval(fnStr));
+  };
+};
+
+exports._unsafePageEvalAll = function(selector, fnStr, page) {
+  return function() {
+    return page.$$eval(selector, eval(fnStr));
+  };
+};

--- a/src/Toppoki.js
+++ b/src/Toppoki.js
@@ -32,12 +32,6 @@ exports._content = function(page) {
   };
 };
 
-exports._content = function(page) {
-  return function() {
-    return page.content();
-  };
-};
-
 exports._screenshot = function(options, page) {
   return function() {
     return page.screenshot(options);

--- a/src/Toppoki.purs
+++ b/src/Toppoki.purs
@@ -181,10 +181,10 @@ runPromiseAffE2 :: forall a b o. FU.Fn2 a b (Effect (Promise o)) -> a -> b -> Af
 runPromiseAffE2 f a b = Promise.toAffE $ FU.runFn2 f a b
 
 runPromiseAffE3 :: forall a b c o. FU.Fn3 a b c (Effect (Promise o)) -> a -> b -> c -> Aff o
-runPromiseAffE3 f a b c =  Promise.toAffE $ FU.runFn3 f a b c
+runPromiseAffE3 f a b c = Promise.toAffE $ FU.runFn3 f a b c
 
 runPromiseAffE4 :: forall a b c d o. FU.Fn4 a b c d (Effect (Promise o)) -> a -> b -> c -> d -> Aff o
-runPromiseAffE4 f a b c d =  Promise.toAffE $ FU.runFn4 f a b c d
+runPromiseAffE4 f a b c d = Promise.toAffE $ FU.runFn4 f a b c d
 
 foreign import puppeteer :: Puppeteer
 foreign import _launch :: forall options. FU.Fn1 options (Effect (Promise Browser))

--- a/src/Toppoki.purs
+++ b/src/Toppoki.purs
@@ -202,6 +202,54 @@ runPromiseAffE3 f a b c = Promise.toAffE $ FU.runFn3 f a b c
 runPromiseAffE4 :: forall a b c d o. FU.Fn4 a b c d (Effect (Promise o)) -> a -> b -> c -> d -> Aff o
 runPromiseAffE4 f a b c d = Promise.toAffE $ FU.runFn4 f a b c d
 
+-- | See [USKeyboardLayout](https://github.com/GoogleChrome/puppeteer/blob/v1.18.1/lib/USKeyboardLayout.js) for a list of all key names.
+newtype KeyboardKey = KeyboardKey String
+
+-- | Dispatches a keydown event.
+keyboardDown :: forall options trash
+              . Row.Union options trash ( text :: String )
+             => KeyboardKey
+             -> { | options }
+             -> Page
+             -> Aff Unit
+keyboardDown key options page = runPromiseAffE3 _keyboardDown key options page
+
+-- | Trigger a single keypress. Shortcut for `keyboard.down` and `keyboard.up`.
+keyboardPress
+  :: forall options trash
+   . Row.Union options trash
+       ( delay :: Int
+       , text :: String
+       )
+  => KeyboardKey
+  -> { | options }
+  -> Page
+  -> Aff Unit
+keyboardPress = runPromiseAffE3 _keyboardPress
+
+-- | Dispatches a keypress and input event. This does not send a keydown or keyup event.
+keyboardSendCharacter :: String -> Page -> Aff Unit
+keyboardSendCharacter char page = runPromiseAffE2 _keyboardSendCharacter char page
+
+-- | Sends a keydown, keypress/input, and keyup event for each character in the text.
+-- | To press a special key, like Control or ArrowDown, use keyboard.press.
+keyboardType :: forall options trash
+              . Row.Union options trash ( delay :: Number )
+             => String
+             -> { | options }
+             -> Page
+             -> Aff Unit
+keyboardType = runPromiseAffE3 _keyboardType
+
+-- | Dispatches a keyup event.
+keyboardUp :: forall options trash
+              . Row.Union options trash ( text :: String )
+             => KeyboardKey
+             -> { | options }
+             -> Page
+             -> Aff Unit
+keyboardUp key options page = runPromiseAffE3 _keyboardUp key options page
+
 foreign import puppeteer :: Puppeteer
 foreign import _launch :: forall options. FU.Fn1 options (Effect (Promise Browser))
 foreign import _newPage :: FU.Fn1 Browser (Effect (Promise Page))
@@ -220,3 +268,8 @@ foreign import _getLocationHref :: FU.Fn1 Page (Effect (Promise String))
 foreign import _unsafeEvaluateStringFunction :: FU.Fn2 String Page (Effect (Promise Foreign))
 foreign import _unsafePageEval :: FU.Fn3 Selector String Page (Effect (Promise Foreign))
 foreign import _unsafePageEvalAll :: FU.Fn3 Selector String Page (Effect (Promise Foreign))
+foreign import _keyboardDown :: forall options. FU.Fn3 KeyboardKey options Page (Effect (Promise Unit))
+foreign import _keyboardPress :: forall options. FU.Fn3 KeyboardKey options Page (Effect (Promise Unit))
+foreign import _keyboardSendCharacter :: FU.Fn2 String Page (Effect (Promise Unit))
+foreign import _keyboardType :: forall options. FU.Fn3 String options Page (Effect (Promise Unit))
+foreign import _keyboardUp :: forall options. FU.Fn3 KeyboardKey options Page (Effect (Promise Unit))

--- a/src/Toppoki.purs
+++ b/src/Toppoki.purs
@@ -174,6 +174,22 @@ getLocationRef p = Promise.toAffE $ FU.runFn1 _getLocationHref p
 unsafeEvaluateStringFunction :: String -> Page -> Aff Foreign
 unsafeEvaluateStringFunction = runPromiseAffE2 _unsafeEvaluateStringFunction
 
+-- | This method runs document.querySelector within the page and passes it as the first argument to pageFunction. If there's no element matching selector, the method throws an error.
+-- |
+-- | Second argument is a pageFunction which should be a valid JavaScript function written as a string which we unsafely eval.
+-- |
+-- | If pageFunction returns a Promise, then page.$$eval would wait for the promise to resolve and return its value.
+unsafePageEval :: Selector -> String -> Page -> Aff Foreign
+unsafePageEval = runPromiseAffE3 _unsafePageEval
+
+-- | This method runs Array.from(document.querySelectorAll(selector)) within the page and passes it as the first argument to pageFunction.
+-- |
+-- | Second argument is a pageFunction which should be a valid JavaScript function written as a string which we unsafely eval.
+-- |
+-- | If pageFunction returns a Promise, then page.$$eval would wait for the promise to resolve and return its value.
+unsafePageEvalAll :: Selector -> String -> Page -> Aff Foreign
+unsafePageEvalAll = runPromiseAffE3 _unsafePageEvalAll
+
 runPromiseAffE1 :: forall a o. FU.Fn1 a (Effect (Promise o)) -> a -> Aff o
 runPromiseAffE1 f a = Promise.toAffE $ FU.runFn1 f a
 
@@ -202,3 +218,5 @@ foreign import _click :: FU.Fn2 Selector Page (Effect (Promise Unit))
 foreign import _waitForNavigation :: forall options. FU.Fn2 options Page (Effect (Promise Unit))
 foreign import _getLocationHref :: FU.Fn1 Page (Effect (Promise String))
 foreign import _unsafeEvaluateStringFunction :: FU.Fn2 String Page (Effect (Promise Foreign))
+foreign import _unsafePageEval :: FU.Fn3 Selector String Page (Effect (Promise Foreign))
+foreign import _unsafePageEvalAll :: FU.Fn3 Selector String Page (Effect (Promise Foreign))

--- a/test/test.html
+++ b/test/test.html
@@ -1,0 +1,3 @@
+<div class="eval-one">abc</div>
+<div class="eval-many">abc</div>
+<div class="eval-many">def</div>

--- a/test/test.html
+++ b/test/test.html
@@ -1,3 +1,7 @@
 <div class="eval-one">abc</div>
 <div class="eval-many">abc</div>
 <div class="eval-many">def</div>
+<input type="text" id="test-press"/>
+<input type="text" id="test-type"/>
+<input type="text" id="test-downup"/>
+<input type="text" id="test-sendcharacter"/>


### PR DESCRIPTION
First off, this is the first PureScript PR I've made that contains more than a line or two 🎉 . That's why I'd ask to please be liberal with picking it apart. I'm trying to learn PureScript here and pick up on idioms, and even nits are welcome! You'd be helping, not offending me 😁 .

The method implemented: [keyboard.press](https://github.com/GoogleChrome/puppeteer/blob/v1.18.1/docs/api.md#keyboardpresskey-options).

The Page object has a keyboard property which allows sending keypresses.
This PR adds the most straightforward of the Keyboard methods, sending a
single keypress of choice.

Points to discuss:
* I don't know if it's okay to access [the keyboard property on the page object](https://github.com/GoogleChrome/puppeteer/blob/v1.18.1/docs/api.md#pagekeyboard), it doesn't look like you can do much with the object so I couldn't come up with a reason we might want a `foreign import data Keyboard` even though it might exist.
* `KeyName` is not a great name but it's also possible to make it safe by getting the list of options now linked in a comment into the code. I'm not sure what the best way would be, or where this long list should go. If you can link me an example, I'm happy to make the required changes!
* In the test I use `unsafeEvaluateStringFunction` to get at the value in the input we use to register the effect of the keyboard event. If we can use puppeteer APIs to get at it safely, I imagine that would be nicer, but we don't have `getProperty` or `ElementHandle` yet.

Thanks for taking the time to review 🙏 .