### PR TITLE
add executablePath to LaunchOptions

### DIFF
--- a/src/Toppoki.purs
+++ b/src/Toppoki.purs
@@ -27,20 +27,21 @@ newtype Selector = Selector String
 derive instance newtypeSelector :: Newtype Selector _
 
 type LaunchOptions =
-  ( headless          :: Boolean
-  , args              :: Array String
-  , ignoreDefaultArgs :: Array String
-  , ignoreHTTPSErrors :: Boolean
-  , slowMo            :: Number
+  ( args              :: Array String
   , defaultViewport   :: Record DefaultViewPort
+  , devtools          :: Boolean
+  , dumpio            :: Boolean
+  , executablePath    :: String
+  , handleSIGHUP      :: Boolean
   , handleSIGINT      :: Boolean
   , handleSIGTERM     :: Boolean
-  , handleSIGHUP      :: Boolean
-  , timeout           :: Number
-  , dumpio            :: Boolean
-  , userDataDir       :: String
-  , devtools          :: Boolean
+  , headless          :: Boolean
+  , ignoreDefaultArgs :: Array String
+  , ignoreHTTPSErrors :: Boolean
   , pipe              :: Boolean
+  , slowMo            :: Number
+  , timeout           :: Number
+  , userDataDir       :: String
   )
 
 type DefaultViewPort =


### PR DESCRIPTION
Needed the ability to launch Chrome instead of Chromium and was missing this options in the `LaunchOptions`.

Whilst I was there I ordered the values alphabetically to please my ocd!!